### PR TITLE
Improved pretty printing, to include reordering list values.

### DIFF
--- a/migrate.py
+++ b/migrate.py
@@ -706,6 +706,17 @@ def do_json_difference(args):
 # json-pretty-print subcommand
 # -----------------------------------------------------------------------------
 
+def normalizeJsonListOrderingForPrinting(jsondoc):
+    '''Alters a recursive json document by re-ording lists to a standard order '''
+    for key, value in jsondoc.items():
+        # Handle maps.
+        if isinstance(value, collections.Mapping):
+            normalizeJsonListOrderingForPrinting(value)
+        # Handle lists.
+        elif isinstance(value, list):
+            for list_element in value:
+                normalizeJsonListOrderingForPrinting(list_element)
+            value.sort()
 
 def do_json_pretty_print(args):
     '''A generic JSON pretty print which sorts the JSON keys and indents. '''
@@ -729,6 +740,10 @@ def do_json_pretty_print(args):
 
     with open(input_filename) as input_file:
         input_dictionary = json.load(input_file)
+
+    # Normalize the ordering of JSON lists.
+
+    normalizeJsonListOrderingForPrinting(input_dictionary)
 
     # Write the output JSON file.
 

--- a/migrate.py
+++ b/migrate.py
@@ -743,7 +743,7 @@ def do_json_pretty_print(args):
 
     # Normalize the ordering of JSON lists.
 
-    normalizeJsonListOrderingForPrinting(input_dictionary)
+    normalize_json_list_ordering_for_printing(input_dictionary)
 
     # Write the output JSON file.
 

--- a/migrate.py
+++ b/migrate.py
@@ -711,7 +711,7 @@ def normalize_json_list_ordering_for_printing(jsondoc):
     for key, value in jsondoc.items():
         # Handle maps.
         if isinstance(value, collections.Mapping):
-            normalizeJsonListOrderingForPrinting(value)
+            normalize_json_list_ordering_for_printing(value)
         # Handle lists.
         elif isinstance(value, list):
             for list_element in value:

--- a/migrate.py
+++ b/migrate.py
@@ -706,7 +706,7 @@ def do_json_difference(args):
 # json-pretty-print subcommand
 # -----------------------------------------------------------------------------
 
-def normalizeJsonListOrderingForPrinting(jsondoc):
+def normalize_json_list_ordering_for_printing(jsondoc):
     '''Alters a recursive json document by re-ording lists to a standard order '''
     for key, value in jsondoc.items():
         # Handle maps.

--- a/migrate.py
+++ b/migrate.py
@@ -715,7 +715,7 @@ def normalize_json_list_ordering_for_printing(jsondoc):
         # Handle lists.
         elif isinstance(value, list):
             for list_element in value:
-                normalizeJsonListOrderingForPrinting(list_element)
+                normalize_json_list_ordering_for_printing(list_element)
             value.sort()
 
 def do_json_pretty_print(args):


### PR DESCRIPTION
## Which issue does this address

When we pretty-print the configuration documents, the lists of values should also be sorted, in order to give consistent results, easy to read through a diff-viewer.

## Why was change needed

In comparing two different versions of g2config.json, I found the tags badly ordered, and the results very difficult to read.  This change allowed me to reorder them logically, and more easily compare.

## What does change improve

It improves the ability to compare different g2config.json files with each other, to see what differences exist between them.
